### PR TITLE
Update MiningAssist

### DIFF
--- a/Pack10/src/config/cavern/general.cfg
+++ b/Pack10/src/config/cavern/general.cfg
@@ -37,6 +37,22 @@ general {
         oreTin,1
         oreUranium,2
         minecraft:lit_redstone_ore,2
+        oreNickel,1
+        oreClathrateRedstone,1
+        oreOsmium,1
+        oreRuby,1
+        oreSapphire,1
+        orePeridot,1
+        oreElectrotine,1
+        oreCertusQuartz,1
+        contenttweaker:mercurium_ore,1
+        contenttweaker:venerium_ore,1
+        contenttweaker:lunium_ore,1
+        contenttweaker:martium_ore,1
+        contenttweaker:giovenium_ore,1
+        contenttweaker:saturnium_ore,1
+        contenttweaker:solenium_ore,1
+        sakura:sakura_diamond_ore,1
      >
 
     # 採掘コンボを有効にします。

--- a/Pack10/src/config/cavern/mining-assist.cfg
+++ b/Pack10/src/config/cavern/mining-assist.cfg
@@ -34,38 +34,37 @@ miningassist {
     # 一括破壊の対象となるブロックを指定します。何も指定されていない場合は自動判別されます。
     # Note: If multiplayer, server-side only.
     S:quickTargetBlocks <
-    minecraft:coal_ore
-    minecraft:iron_ore
-    minecraft:redstone_ore
+    glowstone
+    oreCoal
+    oreIron
+    oreRedstone
     minecraft:lit_redstone_ore
-    minecraft:lapis_ore
-    minecraft:diamond_ore
-    minecraft:emerald_ore
-    minecraft:quartz_ore
-    minecraft:gold_ore
-    thermalfoundation:ore
-    thermalfoundation:ore:1
-    thermalfoundation:ore:2
-    thermalfoundation:ore:3
-    thermalfoundation:ore:5
-    thermalfoundation:ore_fluid:2
-    cavern:cave_block
-    cavern:cave_block:2
-    cavern:cave_block:5
-    mekanism:oreblock
-    projectred-exploration:ore
-    projectred-exploration:ore:1
-    projectred-exploration:ore:2
-    projectred-exploration:ore:6
-    forestry:resources
-    appliedenergistics2:quartz_ore
-    appliedenergistics2:charged_quartz_ore
-    immersiveengineering:ore:5
-    tconstruct:ore
-    tconstruct:ore:1
-    thaumcraft:ore_cinnabar
-    thaumcraft:ore_amber
-    thaumcraft:ore_quartz
+    oreLapis
+    oreDiamond
+    oreEmerald
+    oreQuartz
+    oreGold
+    oreCopper
+    oreTin
+    oreSilver
+    oreLead
+    oreNickel
+    oreClathrateRedstone
+    oreAquamarine
+    oreMagnite
+    oreHexcite
+    oreOsmium
+    oreRuby
+    oreSapphire
+    orePeridot
+    oreElectrotine
+    oreApatite
+    oreCertusQuartz
+    oreUranium
+    oreCobalt
+    oreArdite
+    oreCinnabar
+    oreAmber
     contenttweaker:mercurium_ore
     contenttweaker:venerium_ore
     contenttweaker:lunium_ore
@@ -73,6 +72,7 @@ miningassist {
     contenttweaker:giovenium_ore
     contenttweaker:saturnium_ore
     contenttweaker:solenium_ore
+    sakura:sakura_diamond_ore
      >
 
     # 範囲破壊の対象となるブロックを指定します。何も指定されていない場合は自動判別されます。


### PR DESCRIPTION
一括破壊の対象に入れ忘れていた鉱石の追加、採掘ランクにポイントが入る鉱石を一括破壊の対象の鉱石に合わせた